### PR TITLE
Fix compile errors for parsers using `concatenate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ contain some use cases using pars3k.
 ## Usage
 
 ```cr
-require "p3k"
+require "pars3k"
 include Pars3k
 ```
 

--- a/src/pars3k.cr
+++ b/src/pars3k.cr
@@ -508,6 +508,10 @@ module Pars3k
 				constant "#{whole}#{decimal.size == 0 ? ".0" : "." + decimal}".to_f
 			})
 		end
+
+		private def self.concatenate(chars : Array(Char))
+			chars.reduce "" { |v, c| v + c }
+		end
 	end
 
 	# Parser(T) is a parser with return type T.
@@ -633,10 +637,6 @@ module Pars3k
 				end
 			end
 		end
-	end
-
-	def concatenate(chars : Array(Char))
-		chars.reduce "" { |v, c| v + c }
 	end
 end
 

--- a/src/pars3k.cr
+++ b/src/pars3k.cr
@@ -469,7 +469,7 @@ module Pars3k
 		#
 		# Parses a full word of at least one character.
 		def self.word
-			(one_or_more_of alphabet).transform { |c| concatenate c }
+			(one_or_more_of alphabet).transform &.join
 		end
 
 		# ```cr
@@ -487,7 +487,7 @@ module Pars3k
 		#
 		# Parses an integer as an actual `Int`.
 		def self.int
-			(one_or_more_of digit).transform { |c| (concatenate c).to_i }
+			(one_or_more_of digit).transform &.join
 		end
 
 		# ```cr
@@ -507,10 +507,6 @@ module Pars3k
 				decimal <= (join many_of digit),
 				constant "#{whole}#{decimal.size == 0 ? ".0" : "." + decimal}".to_f
 			})
-		end
-
-		private def self.concatenate(chars : Array(Char))
-			chars.reduce "" { |v, c| v + c }
 		end
 	end
 


### PR DESCRIPTION
Resolves an issue where using parsers that relied on the `concatenate` util method wouldn't compile. Looks to have just been incorrectly scoped.